### PR TITLE
Fix the rstudioapi package not found error when invoke install_azureml

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,9 +18,9 @@ RoxygenNote: 6.1.1
 Imports:
     reticulate (>= 1.12),
     R6 (>= 2.4.0),
-    plyr (>= 1.8)
+    plyr (>= 1.8),
+    rstudioapi (>= 0.7)
 Suggests: rmarkdown,
     knitr,
-    testthat,
-    rstudioapi (>= 0.7)
+    testthat
 VignetteBuilder: knitr

--- a/R/install.R
+++ b/R/install.R
@@ -44,7 +44,7 @@ install_azureml <- function(version = NULL,
 
   cat("\nInstallation complete.\n\n")
   
-  if (rstudioapi::hasFun("restartSession"))
+  if (rstudioapi::isAvailable() && rstudioapi::hasFun("restartSession"))
     rstudioapi::restartSession()
   
   invisible(NULL)


### PR DESCRIPTION
Fix the rstudioapi package not found error when invoke install_azureml on rstudio server on a notebook vm.