### PR TITLE
Remove use_conda() to unblock the testing on CRAN build machine.

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -1,11 +1,9 @@
 # Copyright(c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-#' @importFrom reticulate import use_condaenv py_str
+#' @importFrom reticulate import py_str
 
 .onLoad <- function(libname, pkgname) {
-  use_condaenv("r-azureml")
-
   # delay load azureml
   azureml <<- import("azureml", delay_load = list(
     environment = "r-azureml",


### PR DESCRIPTION
2179#> Error: package or namespace load failed for ‘azureml’:
2180#> .onLoad failed in loadNamespace() for 'azureml', details:
2181#> call: NULL
2182#> error: Unable to find conda binary. Is Anaconda installed?
2183#> Error: loading failed
