### PR TITLE
fixes to vignettes

### DIFF
--- a/vignettes/README.md
+++ b/vignettes/README.md
@@ -1,6 +1,8 @@
 ## Azure ML vignettes
 These vignettes are end-to-end tutorials for using the Azure Machine Learning service with the R SDK.
 
+Before running a vignette in RStudio, set the directory to the folder that contains the vignette file (.Rmd file) in RStudio using `setwd(dirname)` or Session -> Set Working Directory -> To Source File Location. Each vignette assumes that the data and scripts are in the current working directory.
+
 The following vignettes are included:
 1. [installation](installation.Rmd): Install the Azure ML SDK for R.
 2. [configuration](configuration.Rmd): Set up an Azure ML workspace.

--- a/vignettes/deploy-to-aks/deploy-to-aks.Rmd
+++ b/vignettes/deploy-to-aks/deploy-to-aks.Rmd
@@ -93,6 +93,7 @@ Now you have everything you need to create an inference config for encapsulating
 ``` {r create_inference_config, eval=FALSE}
 inference_config <- inference_config(
   entry_script = "score.R",
+  source_directory = ".",
   environment = r_env)
 ```
 

--- a/vignettes/hyperparameter-tune-with-keras/hyperparameter-tune-with-keras.Rmd
+++ b/vignettes/hyperparameter-tune-with-keras/hyperparameter-tune-with-keras.Rmd
@@ -61,17 +61,19 @@ By using Azure Machine Learning Compute (AmlCompute), a managed service, data sc
 You may need to wait a few minutes for your compute cluster to be provisioned if it doesn't already exist.
 
 ```{r create_cluster, eval=FALSE}
-cluster_name <- "rcluster"
+cluster_name <- "gpucluster"
 
 compute_target <- get_compute(ws, cluster_name = cluster_name)
 if (is.null(compute_target))
 {
   vm_size <- "STANDARD_NC6"
-  compute_target <- create_aml_compute(workspace = ws, cluster_name = cluster_name,
-                                       vm_size = vm_size, max_nodes = 4)
+  compute_target <- create_aml_compute(workspace = ws, 
+                                       cluster_name = cluster_name,
+                                       vm_size = vm_size, 
+                                       max_nodes = 4)
+  
+  wait_for_provisioning_completion(compute_target, show_output = TRUE)
 }
-
-wait_for_provisioning_completion(compute_target, show_output = TRUE)
 ```
 
 ## Prepare the training script

--- a/vignettes/train-and-deploy-to-aci/train-and-deploy-to-aci.Rmd
+++ b/vignettes/train-and-deploy-to-aci/train-and-deploy-to-aci.Rmd
@@ -77,9 +77,9 @@ if (is.null(compute_target)) {
                                        cluster_name = cluster_name,
                                        vm_size = vm_size,
                                        max_nodes = 1)
+  
+  wait_for_provisioning_completion(compute_target, show_output = TRUE)
 }
-
-wait_for_provisioning_completion(compute_target)
 ```
 
 ## Prepare data for training
@@ -253,6 +253,7 @@ Now you have everything you need to create an **inference config** for encapsula
 ``` {r create_inference_config, eval=FALSE}
 inference_config <- inference_config(
   entry_script = "accident_predict.R",
+  source_directory = ".",
   environment = r_env)
 ```
 

--- a/vignettes/train-with-tensorflow/train-with-tensorflow.Rmd
+++ b/vignettes/train-with-tensorflow/train-with-tensorflow.Rmd
@@ -52,17 +52,19 @@ By using Azure Machine Learning Compute (AmlCompute), a managed service, data sc
 You may need to wait a few minutes for your compute cluster to be provisioned if it doesn't already exist.
 
 ```{r create_cluster, eval=FALSE}
-cluster_name <- "rcluster"
+cluster_name <- "gpucluster"
 
 compute_target <- get_compute(ws, cluster_name = cluster_name)
 if (is.null(compute_target))
 {
   vm_size <- "STANDARD_NC6"
-  compute_target <- create_aml_compute(workspace = ws, cluster_name = cluster_name,
-                                       vm_size = vm_size, max_nodes = 1)
+  compute_target <- create_aml_compute(workspace = ws, 
+                                       cluster_name = cluster_name,
+                                       vm_size = vm_size, 
+                                       max_nodes = 4)
+  
+  wait_for_provisioning_completion(compute_target, show_output = TRUE)
 }
-
-wait_for_provisioning_completion(compute_target, show_output = TRUE)
 ```
 
 ## Prepare the training script


### PR DESCRIPTION
- add `source_directory` param to `inference_config` calls to address issue #154 
- update README.md
- name the cluster used in tf and hyperdrive vignettes "gpucluster" with `max_nodes = 4` so that users can run all the vignettes and reuse the appropriate clusters
- move `wait_for_provisioning` call for compute inside if/else