### PR TITLE
override workspace object string representation

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -10,9 +10,12 @@
 
     on_load = function() {
       # This function will be called on successful load
+
+      # set user agent
       ver <- toString(utils::packageVersion("azuremlsdk"))
       azureml$"_base_sdk_common"$user_agent$append("azureml-r-sdk", ver)
-      
+
+      # override workspace __repr__ from python
       azureml$core$Workspace$"__repr__" <- function(self) {
         sprintf("create_workspace(name=\"%s\", subscription_id=\"%s\", resource_group=\"%s\")", 
           self$"_workspace_name",

--- a/R/package.R
+++ b/R/package.R
@@ -12,6 +12,13 @@
       # This function will be called on successful load
       ver <- toString(utils::packageVersion("azuremlsdk"))
       azureml$"_base_sdk_common"$user_agent$append("azureml-r-sdk", ver)
+      
+      azureml$core$Workspace$"__repr__" <- function(self) {
+        sprintf("create_workspace(name=\"%s\", subscription_id=\"%s\", resource_group=\"%s\")", 
+          self$"_workspace_name",
+          self$"_subscription_id",
+          self$"_resource_group")
+        }
     },
 
     on_error = function(e) {


### PR DESCRIPTION
This PR is for addressing below issue:

If you instantiate a workspace object and then call print(ws) or ws, it returns: Workspace.create(name='minxia', subscription_id='15ae9cb6-95c1-483d-a0e3-b1a1a3b06324', resource_group='pytorch')