### PR TITLE
Add pandas installation

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -16,7 +16,7 @@ install_azureml <- function(version = "1.0.85",
                             restart_session = TRUE,
                             remove_existing_env = FALSE) {
   main_package <- "azureml-sdk"
-  default_packages <- c("numpy")
+  default_packages <- c("numpy", "pandas")
 
   # set version if provided
   if (!is.null(version)) {

--- a/man/azureml.Rd
+++ b/man/azureml.Rd
@@ -6,7 +6,7 @@
 \title{azureml module
 User can access functions/modules in azureml that are not exposed through the
 exported R functions.}
-\format{An object of class \code{python.builtin.module} (inherits from \code{python.builtin.object}) of length 5.}
+\format{An object of class \code{python.builtin.module} (inherits from \code{python.builtin.object}) of length 2.}
 \usage{
 azureml
 }


### PR DESCRIPTION
DataPrep SDK no longer installs pandas automatically, so we need to install it ourselves for dataframe/set functions to work reliably.