### PR TITLE
update datasets parameter to take list of lists for register_* methods, not tuple

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -575,7 +575,7 @@ def run(input_data):
 #' @md
 register_model_from_run <- function(run, model_name, model_path = NULL,
                                     tags = NULL, properties = NULL,
-                                    description = NULL, datasets = datasets,
+                                    description = NULL, datasets = NULL,
                                     sample_input_dataset = NULL,
                                     sample_output_dataset = NULL,
                                     resource_configuration = NULL) {

--- a/man/register_model.Rd
+++ b/man/register_model.Rd
@@ -20,8 +20,10 @@ object, as opposed to using the entire contents of the folder.}
 
 \item{model_name}{A string of the name to register the model with.}
 
-\item{datasets}{A list of tuples where the first element describes the
-dataset-model relationship and the second element is the dataset.}
+\item{datasets}{A list of two-element lists where the first element is the
+dataset-model relationship and the second is the corresponding dataset, e.g.
+\code{list(list("training", train_ds), list("inferencing", infer_ds))}. Valid
+values for the data-model relationship are 'training', 'validation', and 'inferencing'.}
 
 \item{tags}{A named list of key-value tags to give the model, e.g.
 \code{list("key" = "value")}}
@@ -58,12 +60,15 @@ model with the same name as an existing one, your workspace's model
 registry assumes that it's a new version. The version is incremented,
 and the new model is registered under the same name.
 }
-\examples{
-# Registering a model from a single file
-\dontrun{
-ws <- load_workspace_from_config()
+\section{Examples}{
+Registering a model from a single file\preformatted{ws <- load_workspace_from_config()
 model <- register_model(ws,
                         model_path = "my_model.rds",
-                        model_name = "my_model")
+                        model_name = "my_model",
+                        datasets = list(list("training", train_dataset)))
 }
+}
+
+\seealso{
+\code{\link[=resource_configuration]{resource_configuration()}}
 }

--- a/man/register_model_from_run.Rd
+++ b/man/register_model_from_run.Rd
@@ -6,7 +6,7 @@
 \usage{
 register_model_from_run(run, model_name, model_path = NULL,
   tags = NULL, properties = NULL, description = NULL,
-  datasets = NULL, sample_input_dataset = NULL,
+  datasets = datasets, sample_input_dataset = NULL,
   sample_output_dataset = NULL, resource_configuration = NULL)
 }
 \arguments{
@@ -24,8 +24,10 @@ These properties cannot be changed after model creation, however new key-value p
 
 \item{description}{An optional description of the model.}
 
-\item{datasets}{A list of tuples where the first element describes the dataset-model
-relationship and the second element is the dataset.}
+\item{datasets}{A list of two-element lists where the first element is the
+dataset-model relationship and the second is the corresponding dataset, e.g.
+\code{list(list("training", train_ds), list("inferencing", infer_ds))}. Valid
+values for the data-model relationship are 'training', 'validation', and 'inferencing'.}
 
 \item{sample_input_dataset}{Sample input dataset for the registered model.}
 
@@ -39,6 +41,17 @@ The registered Model.
 \description{
 Register a model for operationalization.
 }
+\section{Examples}{
+\preformatted{registered_model <- register_model_from_run(run = run,
+                                            model_name = "my model",
+                                            model_path = 'outputs/model.rds',
+                                            tags = list("version" = "0"),
+                                            datasets = list(list("training", train_dataset),
+                                                            list("validation", validation_dataset)),
+                                            resource_configuration = resource_configuration(2, 2, 0))
+}
+}
+
 \seealso{
-\code{\link{resource_configuration}}
+\code{\link[=resource_configuration]{resource_configuration()}}
 }

--- a/man/register_model_from_run.Rd
+++ b/man/register_model_from_run.Rd
@@ -6,7 +6,7 @@
 \usage{
 register_model_from_run(run, model_name, model_path = NULL,
   tags = NULL, properties = NULL, description = NULL,
-  datasets = datasets, sample_input_dataset = NULL,
+  datasets = NULL, sample_input_dataset = NULL,
   sample_output_dataset = NULL, resource_configuration = NULL)
 }
 \arguments{

--- a/tests/testthat/test_model.R
+++ b/tests/testthat/test_model.R
@@ -11,8 +11,14 @@ test_that("get, register, download, serialize, deserialize and delete model", {
   dir.create(tmp_dir_path)
   file.create(file.path(tmp_dir_path, model_name))
   
-  # register the model
-  model <- register_model(ws, tmp_dir_path, model_name)
+  # register the model (with datasets)
+  train_ds <- create_tabular_dataset_from_delimited_files('iris.csv')
+  val_ds <- create_tabular_dataset_from_delimited_files('iris.csv')
+  infer_ds <- create_tabular_dataset_from_delimited_files('iris.csv')
+  model <- register_model(ws, tmp_dir_path, model_name,
+                          datasets = list(list("training", train_ds),
+                                          list("validation", val_ds),
+                                          list("inferencing", infer_ds)))
   
   # get model
   ws_model <- get_model(ws, model_name)


### PR DESCRIPTION
Closes #286 

A tuple in Python = list containing different datatypes in R, so input as list of lists rather than a named list is more straightforward despite @mx-iao's recommendation in the Issue. Though prettier, named list input would require deconstruction and reconstruction as lists before sending off to reticulate :( .