### PR TITLE
Make sample validation print out script name with error

### DIFF
--- a/.azure-pipelines/scripts/validate_samples.R
+++ b/.azure-pipelines/scripts/validate_samples.R
@@ -47,7 +47,7 @@ validate_samples <- function(args) {
       setwd(root_dir)
     },
     error = function(e) {
-      stop(message(e))
+      stop(entry_script, "\n", message(e))
     })
   }
 }


### PR DESCRIPTION
Currently, sample validation failures aren't easy to diagnose because the entry script isn't printed, only the error message is. In some cases, the error message is not enough to figure out which script the error is coming from.