### PR TITLE
Fix failing function tests

### DIFF
--- a/tests/testthat/test_experiment.R
+++ b/tests/testthat/test_experiment.R
@@ -24,7 +24,8 @@ test_that("create, submit experiment, run in default amlcompute,
                    compute_target = existing_compute$name, 
                    entry_script = script_name, 
                    script_params = list("data_folder" = ds$as_mount()),
-                   cran_packages = c("dplyr", "ggplot2"))
+                   cran_packages = list(cran_package("dplyr"),
+                                        cran_package("ggplot2")))
   
   run <- submit_experiment(exp, est)
   wait_for_run_completion(run, show_output = TRUE)
@@ -61,7 +62,8 @@ test_that("submit experiment through a custom environment,
   dir.create(tmp_dir_name)
   file.copy(script_name, tmp_dir_name)
   
-  env <- r_environment("myenv", cran_packages = c("dplyr", "ggplot2"))
+  env <- r_environment("myenv", cran_packages = list(cran_package("dplyr"),
+                                                     cran_package("ggplot2")))
 
   est <- estimator(tmp_dir_name,
                    compute_target = existing_compute$name, 

--- a/tests/testthat/test_model.R
+++ b/tests/testthat/test_model.R
@@ -12,9 +12,18 @@ test_that("get, register, download, serialize, deserialize and delete model", {
   file.create(file.path(tmp_dir_path, model_name))
   
   # register the model (with datasets)
-  train_ds <- create_tabular_dataset_from_delimited_files('iris.csv')
-  val_ds <- create_tabular_dataset_from_delimited_files('iris.csv')
-  infer_ds <- create_tabular_dataset_from_delimited_files('iris.csv')
+  ds <- get_default_datastore(ws)
+
+  file_name <- "iris.csv"
+  upload_files_to_datastore(ds,
+                            files = list(file.path(".", file_name)),
+                            target_path = 'train-dataset/tabular/',
+                            overwrite = TRUE)
+  
+  train_ds <- create_tabular_dataset_from_delimited_files(ds$path('train-dataset/tabular/iris.csv'))
+  val_ds <- create_tabular_dataset_from_delimited_files(ds$path('train-dataset/tabular/iris.csv'))
+  infer_ds <- create_tabular_dataset_from_delimited_files(ds$path('train-dataset/tabular/iris.csv'))
+
   model <- register_model(ws, tmp_dir_path, model_name,
                           datasets = list(list("training", train_ds),
                                           list("validation", val_ds),


### PR DESCRIPTION
- two tests failed due to old cran_packages param format instances that weren't updated in #310 
- one test failed due to an incorrect input for `create_tabular_dataset_from_delimited_files`