### PR TITLE
exclude lines that are tested in samples

### DIFF
--- a/.azure-pipelines/code-quality.yml
+++ b/.azure-pipelines/code-quality.yml
@@ -33,7 +33,27 @@ steps:
       script: |
         Rscript './.azure-pipelines/scripts/check_code_style.R' 'R'
         R -e 'install.packages("covr", repos = "http://cran.us.r-project.org");
-              covr::codecov(token=$(CODECOV_TOKEN))'
+              library(covr);
+              codecov(
+                line_exclusions = list(
+                  "R/environment.R" = c(189:190, 210),
+                  "R/compute.R" = c(79:96, 116:124, 143, 162:163, 182:186, 197:198),
+                  "R/datasets.R" = c(20, 33:34),
+                  "R/datastore.R",
+                  "R/experiment.R",
+                  "R/hyperdrive.R" = c(95:101, 121, 240:241, 353, 407, 630:631, 663:664, 692),
+                  "R/install.R",
+                  "R/keyvault.R" = c(23:24, 1:59),
+                  "R/model.R" = c(34:41, 105:125, 148:149, 244:250, 306:310, 342, 410, 423, 489,
+                                  493:502, 585:600),
+                  "R/package.R",
+                  "R/webservice.R" = c(1:129, 146:147),
+                  "R/webservice-aci.R" = c(63:76),
+                  "R/webservice-local.R" = c(21:22, 67:69),
+                  "R/workspace.R" = c(123:199, 262:344),
+                  "R/run.R" = c(29:60, 178, 254:256, 565:752),
+                  "R/do_azureml_parallel.R" = c(8:59, 66:77, 82:88, 108:109, 113:179, 186:211, 215:312)),
+                token = $(CODECOV_TOKEN))'
     displayName: 'Check code style and code coverage'
 
   - task: Bash@3


### PR DESCRIPTION
CodeCov by default only considers a line covered if it has a test in the tests/testthat folder, but we have samples that run daily which include functions/objects that aren't included in tests/testthat. Taking that into account will give us a more accurate code coverage number.